### PR TITLE
Force scrollbar in order to avoid a layout width change when navigating

### DIFF
--- a/src/Ui.elm
+++ b/src/Ui.elm
@@ -77,7 +77,7 @@ css =
         []
         [ Html.text """
           @import url('https://rsms.me/inter/inter.css');
-          html { font-family: 'Inter', sans-serif; }
+          html { font-family: 'Inter', sans-serif; overflow-y: scroll; }
           @supports (font-variation-settings: normal) {
             html { font-family: 'Inter var', sans-serif; }
           }


### PR DESCRIPTION
When going from a long page to a short one (less than the height of the screen), or vice versa, a scrollbar gets added or removed, causing a layout width change that feels ungraceful.

This PR forces the scrollbar slot to always be present, so that this does not happen.