### PR TITLE
Use scrollbar-gutter on html

### DIFF
--- a/src/Ui.elm
+++ b/src/Ui.elm
@@ -79,7 +79,7 @@ css =
         []
         [ Html.text """
           @import url('https://rsms.me/inter/inter.css');
-          html { font-family: 'Inter', sans-serif; overflow-y: scroll; }
+          html { font-family: 'Inter', sans-serif; scrollbar-gutter: stable; }
           @supports (font-variation-settings: normal) {
             html { font-family: 'Inter var', sans-serif; }
           }


### PR DESCRIPTION
Hi, another highly important contribution from me!

In order to avoid a layout width change when navigating, due to a scrollbar being added or removed, we used to force the scrollbar gutter to be present with `overflow-y: scroll`.
This is not needed anymore thanks to `scrollbar-gutter: stable` which will always reserve space for a potential scrollbar, without adding an ugly empty scrollbar when it’s not needed.

This is [supported in most modern desktop browsers](https://caniuse.com/mdn-css_properties_scrollbar-gutter) now (not needed on mobile since they use overlay scrollbars there) (also just shipped in Firefox very recently, that’s why usage relative support is bad for FF).