### PR TITLE
Pass correctly formatted timestamp for edit event

### DIFF
--- a/src/GroupPage.elm
+++ b/src/GroupPage.elm
@@ -565,7 +565,10 @@ update config group maybeLoggedIn msg model =
                                             Event.MeetInPerson Nothing ->
                                                 ""
                                     , startDate = Event.startTime event |> Date.fromPosix config.timezone |> Ui.datestamp
-                                    , startTime = Ui.timeToString config.timezone (Event.startTime event)
+                                    , startTime =
+                                        Ui.timestamp
+                                            (Time.toHour config.timezone (Event.startTime event))
+                                            (Time.toMinute config.timezone (Event.startTime event))
                                     , duration =
                                         Event.duration event
                                             |> EventDuration.toDuration


### PR DESCRIPTION
**Description**
- #25 is caused by an incorrectly formatted timestamp passed into the time input field, when the hour can be expressed with single digits. For example: `9:05` is passed, but the HTML input type field expects `HH:mm` format (`09:05` in this case)
- This PR replaces the `Ui.timeToString` method with `Ui.timestamp` to ensure the HTML input field is properly formatted.
- fixes #25

**Before**

![Screenshot 2022-03-31 at 13 45 59](https://user-images.githubusercontent.com/13265785/161049406-294b998b-d677-4d59-947d-d67c2f0a5e76.png)

**After**

![Screenshot 2022-03-31 at 13 48 20](https://user-images.githubusercontent.com/13265785/161049424-dd6d84a9-4c7f-49c6-809b-402cc9242d34.png)
