### PR TITLE
Added MeetOnlineAndInPerson event variant and implement it

### DIFF
--- a/Credits.txt
+++ b/Credits.txt
@@ -2,3 +2,4 @@
 
 * [Martin Stewart](https://github.com/MartinSStewart)
 * [Mario Rogic](https://twitter.com/realmario)
+* [Charles Assus](https://github.com/CharlonTank)

--- a/README.md
+++ b/README.md
@@ -39,5 +39,3 @@ postmarkServerToken =
 ```
 
 (Make sure to not accidentally commit it!)
-
-Charlon: I'm currently working on Internationalization, so if you want to help with that, please let me know!

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://meetdown.app/
 ### Contributing
 
 If you want to fix something or add a feature, I recommend asking me about it on Elm slack (I am `@Martin Stewart`) or creating an issue here first.
-It's much less stressful to turn down a feature *before* you have spent time implementing it!
+It's much less stressful to turn down a feature _before_ you have spent time implementing it!
 
 Also make sure to add your name to the Credits.txt if it's your first PR!
 
@@ -23,16 +23,21 @@ Also make sure to add your name to the Credits.txt if it's your first PR!
 ### How do I log in locally?
 
 Easy way: Uncomment these lines in `Backend.elm`
+
 ```elm
         --_ =
         --    Debug.log "login" loginLink
 ```
+
 and then click on the link that appears in the console when you try logging in.
 
 Hard way: Create a postmark account, generate an API key, and paste it in `Env.elm` here:
+
 ```elm
 postmarkServerToken =
     ""
 ```
+
 (Make sure to not accidentally commit it!)
 
+Charlon: I'm currently working on Internationalization, so if you want to help with that, please let me know!

--- a/src/Backend.elm
+++ b/src/Backend.elm
@@ -1462,6 +1462,33 @@ eventReminderEmailContent groupId groupName event =
 
                     Event.MeetInPerson Nothing ->
                         [ Email.Html.text " in person tomorrow." ]
+
+                    Event.MeetOnlineAndInPerson (Just meetingLink) (Just address) ->
+                        [ Email.Html.text " online and in person tomorrow. The event will be accessible with this link "
+                        , Email.Html.a
+                            [ Email.Html.Attributes.href (Link.toString meetingLink) ]
+                            [ Email.Html.text (Link.toString meetingLink) ]
+                        , Email.Html.text " and will be taking place at "
+                        , Email.Html.text (Address.toString address)
+                        , Email.Html.text ". "
+                        ]
+
+                    Event.MeetOnlineAndInPerson (Just meetingLink) Nothing ->
+                        [ Email.Html.text " online and in person tomorrow. The event will be accessible with this link "
+                        , Email.Html.a
+                            [ Email.Html.Attributes.href (Link.toString meetingLink) ]
+                            [ Email.Html.text (Link.toString meetingLink) ]
+                        , Email.Html.text ". "
+                        ]
+
+                    Event.MeetOnlineAndInPerson Nothing (Just address) ->
+                        [ Email.Html.text " online and in person tomorrow. The event will be taking place at "
+                        , Email.Html.text (Address.toString address)
+                        , Email.Html.text ". "
+                        ]
+
+                    Event.MeetOnlineAndInPerson Nothing Nothing ->
+                        [ Email.Html.text " online and in person tomorrow." ]
                )
             ++ [ Email.Html.br [] []
                , Email.Html.br [] []
@@ -1555,6 +1582,38 @@ newEventNotificationEmailContent groupId groupName event currentTime timezone =
 
                     Event.MeetInPerson Nothing ->
                         [ Email.Html.text (" in person " ++ startDateOrTime_ ++ ".") ]
+
+                    Event.MeetOnlineAndInPerson (Just meetingLink) (Just address) ->
+                        [ " online and in person at "
+                            ++ Address.toString address
+                            ++ " "
+                            ++ startDateOrTime_
+                            ++ ". The event will be accessible with this link "
+                            |> Email.Html.text
+                        , Email.Html.a
+                            [ Email.Html.Attributes.href (Link.toString meetingLink) ]
+                            [ Email.Html.text (Link.toString meetingLink) ]
+                        , Email.Html.text ". "
+                        ]
+
+                    Event.MeetOnlineAndInPerson (Just meetingLink) Nothing ->
+                        [ " online and in person "
+                            ++ startDateOrTime_
+                            ++ ". The event will be accessible with this link "
+                            |> Email.Html.text
+                        , Email.Html.a
+                            [ Email.Html.Attributes.href (Link.toString meetingLink) ]
+                            [ Email.Html.text (Link.toString meetingLink) ]
+                        , Email.Html.text ". "
+                        ]
+
+                    Event.MeetOnlineAndInPerson Nothing (Just address) ->
+                        [ Email.Html.text
+                            (" online and in person at " ++ Address.toString address ++ " " ++ startDateOrTime_ ++ ".")
+                        ]
+
+                    Event.MeetOnlineAndInPerson Nothing Nothing ->
+                        [ Email.Html.text (" online and in person " ++ startDateOrTime_ ++ ".") ]
                )
             ++ [ Email.Html.br [] []
                , Email.Html.br [] []

--- a/src/Env.elm
+++ b/src/Env.elm
@@ -26,6 +26,7 @@ domain =
     "http://localhost:8000"
 
 
+postmarkServerToken : String
 postmarkServerToken =
     ""
 

--- a/src/Event.elm
+++ b/src/Event.elm
@@ -102,6 +102,7 @@ removeAttendee userId (Event event) =
 type EventType
     = MeetOnline (Maybe Link)
     | MeetInPerson (Maybe Address)
+    | MeetOnlineAndInPerson (Maybe Link) (Maybe Address)
 
 
 name : Event -> EventName

--- a/src/Untrusted.elm
+++ b/src/Untrusted.elm
@@ -74,6 +74,18 @@ eventType (Untrusted a) =
         MeetInPerson Nothing ->
             MeetInPerson Nothing |> Just
 
+        MeetOnlineAndInPerson (Just link) Nothing ->
+            Link.toString link |> Link.fromString |> Maybe.map (\result -> MeetOnlineAndInPerson (Just result) Nothing)
+
+        MeetOnlineAndInPerson Nothing (Just address) ->
+            Address.toString address |> Address.fromString |> Result.toMaybe |> Maybe.map (\result -> MeetOnlineAndInPerson Nothing (Just result))
+
+        MeetOnlineAndInPerson Nothing Nothing ->
+            MeetOnlineAndInPerson Nothing Nothing |> Just
+
+        MeetOnlineAndInPerson (Just link) (Just address) ->
+            MeetOnlineAndInPerson (Link.toString link |> Link.fromString) (Address.toString address |> Address.fromString |> Result.toMaybe) |> Just
+
 
 description : Untrusted Description -> Maybe Description
 description (Untrusted a) =


### PR DESCRIPTION
Hello!

Here is a little PR that allows organisers to have a possibility to create an event online and in person.

This was a cool 2 hours exercice I did with a student to dive a bit into Lamdera and Meetdown!
Also, this student created an event on Meetdown and all the events he usually create are online and in person so that's why we did this.

No need for any migration too.

:)