### PR TITLE
Fix dark-reader

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,0 +1,1 @@
+<meta name="darkreader-lock">


### PR DESCRIPTION
Meetdown is unusable with Dark Reader. Adding this to head.html fixes it:

`<meta name="darkreader-lock">`